### PR TITLE
remove telegram bot & NodeJs cyberdrop-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ List of downloaders built by the community. If you have created a downloader or 
 * [cyberdrop-downloader](https://github.com/GuraGaoGao/cyberdrop-downloader) by [@GuraGaoGao](https://github.com/GuraGaoGao)
 * [Amenly_CyberDrop](https://github.com/Amenly/CyberDrop) by [@Amenly](https://github.com/Amenly)
 
-## NodeJS  
-* [cyberdrop-cli](https://github.com/izqalan/CyberDrop-cli) by [@izqalan](https://github.com/izqalan) :heavy_check_mark:
+## NodeJS 
 * [cyberdrop-downloader](https://www.npmjs.com/package/cyberdrop-downloader) by [@Fshy](https://gitlab.com/Fshy)
 
 ## .NET
@@ -29,8 +28,6 @@ List of downloaders built by the community. If you have created a downloader or 
 ## Shell Script 
 * [cyberdrop-downloader (Bash)](https://github.com/sukenn/cyberdrop-downloader) by [@sukenn](https://github.com/sukenn) :heavy_check_mark:
 
-## Telegram Bot
-* [@CyberdropBot](https://github.com/izqalan/Cyberdrop-Telegram) by [@izqalan](https://github.com/izqalan)
 
 
 


### PR DESCRIPTION
I will no longer maintaining these repositories.